### PR TITLE
LeaderState should work with non-contiguous node ids

### DIFF
--- a/src/interchange.rs
+++ b/src/interchange.rs
@@ -68,7 +68,7 @@ impl<T> RemoteProcedureCall<T> {
 }
 
 /// Data interchange format for RPC responses.
-/// * `Accepted` mean that it worked.
+/// * `Accepted` means that it worked.
 /// * `Rejected` means that `rpc.term < node.persistent_state.current_term` or if the
 /// Node's `log` doesn't contain the entry at `rpc.prev_log_index` that maches `prev_log_term`.
 /// The caller should follow the `current_leader` it is directed to.


### PR DESCRIPTION
This PR fixes a couple of issues with `LeaderState`:

1) The default value for `next_index` of followers should be the Leader's `latest_index` as of the election, not 0.
2) The LeaderState should keep `next_index` and `match_index` values in a map instead of a vec, since node id's can be non-contiguous, and may not start at 0.