### PR TITLE
Added blank line between functions exceeding one line and top-level constructs

### DIFF
--- a/src/interchange.rs
+++ b/src/interchange.rs
@@ -105,6 +105,7 @@ impl RemoteProcedureResponse {
             next_index: next_index,
         })
     }
+
     /// Creates a new RemoteProcedureResponse::rejected.
     pub fn reject(uuid: Uuid, term: Term,
                   match_index: LogIndex, next_index: LogIndex)


### PR DESCRIPTION
I had trouble reading most of the code, because of blank space conventions. I suggest adding one blank space between top-level constructs, non-trivial functions, and functions exceeding one line. Note that this is only a suggestion, since Rust hasn't established blank space conventions; however, this is the convention I've followed based on the Google C++ style guide and cpplint.