### PR TITLE
Replica

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate rand;
 #[macro_use] extern crate log;
 extern crate mio;
 pub mod state;
+pub mod state_machine;
 pub mod store;
 pub mod node;
 pub mod interchange;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,42 +3,34 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/Hoverbear/raft/master/raft.png")]
 #![doc(html_root_url = "https://hoverbear.github.io/raft/raft/")]
 
-#![feature(
-    collections,
-    convert,
-    io,
-)]
+#![feature(collections, convert)]
 
+extern crate capnp;
+extern crate mio;
+extern crate rand;
 extern crate rustc_serialize;
 extern crate uuid;
-extern crate rand;
 #[macro_use] extern crate log;
-extern crate mio;
+
+pub mod interchange;
+pub mod node;
 pub mod state;
 pub mod state_machine;
 pub mod store;
-pub mod node;
-pub mod interchange;
 
-use std::{io, str, thread};
-use std::collections::{HashMap, HashSet, VecDeque, BitSet};
+pub mod messages_capnp {
+    include!(concat!(env!("OUT_DIR"), "/messages_capnp.rs"));
+}
+
+use std::{io, ops};
+use std::collections::HashSet;
 use std::fmt::Debug;
-use std::num::Int;
-use std::net::SocketAddr;
-use std::ops;
 use std::marker::PhantomData;
+use std::net::SocketAddr;
 
-use rand::{thread_rng, Rng, ThreadRng};
-use rustc_serialize::{json, Encodable, Decodable};
-
-// MIO
-use mio::udp::UdpSocket;
-use mio::{Token, EventLoop, Handler, ReadHint};
+use rustc_serialize::{Encodable, Decodable};
 
 // Data structures.
-use state::{LeaderState, VolatileState};
-use state::NodeState::{Leader, Follower, Candidate};
-use state::{NodeState, TransactionState, Transaction};
 use store::Store;
 use node::RaftNode;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate uuid;
 
 pub mod interchange;
 pub mod node;
+pub mod replica;
 pub mod state;
 pub mod state_machine;
 pub mod store;

--- a/src/messages.capnp
+++ b/src/messages.capnp
@@ -17,30 +17,32 @@ struct RpcResponse {
 struct AppendEntriesRequest {
 
   term @0 :UInt64;
-  # The leader's term
+  # The leader's term.
 
-  leader @1 :Text;
-  # The leader requesting append entries
+  prevLogIndex @1 :UInt64;
+  # Index of log entry immediately preceding new ones.
 
-  prevLogIndex @2 :UInt64;
-  # Index of log entry immediately preceding new ones
+  prevLogTerm @2 :UInt64;
+  # Term of prevLogIndex entry.
 
-  prevLogTerm @3 :UInt64;
-  # Term of prevLogIndex entry
-
-  entries @4 :List(Data);
+  entries @3 :List(Data);
   # Log entries to store (empty for heartbeat; may send more than one for
-  # efficiency)
+  # efficiency).
 
-  leaderCommit @5 :UInt64;
-  # leader’s commit index
+  leaderCommit @4 :UInt64;
+  # leader’s commit index.
 }
 
 struct AppendEntriesResponse {
 
+    struct LogInfo {
+        term @0 :UInt64;
+        index @1 :UInt64;
+    }
+
   union {
-    success @0 :Void;
-    # The `AppendEntries` request was a success
+    success @0 :LogInfo;
+    # The `AppendEntries` request was a success.
 
     staleTerm @1 :UInt64;
     # The `AppendEntries` request failed because the follower has a greater term
@@ -48,7 +50,7 @@ struct AppendEntriesResponse {
 
     inconsistentPrevEntry @2 :Void;
     # The `AppendEntries` request failed because the follower failed the
-    # previous entry term and index checks
+    # previous entry term and index checks.
 
     internalError @3 :Text;
     # an internal error occured; a description is included.
@@ -58,16 +60,13 @@ struct AppendEntriesResponse {
 struct RequestVoteRequest {
 
   term @0 :UInt64;
-  # The candidate's term
+  # The candidate's term.
 
-  candidate @1 :Text;
-  # The candidate requesting a vote
+  lastLogIndex @1 :UInt64;
+  # The index of the candidate's last log entry.
 
-  lastLogIndex @2 :UInt64;
-  # The index of the candidate's last log entry
-
-  lastLogTerm @3 :UInt64;
-  # The term of the candidate's last log entry
+  lastLogTerm @2 :UInt64;
+  # The term of the candidate's last log entry.
 }
 
 struct RequestVoteResponse {
@@ -82,13 +81,27 @@ struct RequestVoteResponse {
 
     alreadyVoted @2 :Void;
     # The voter did not vote for the candidate, because the voter already voted
-    # in the term
+    # in the term.
 
     inconsistentLog @3 :Void;
     # The `RequestVote` request failed because the candidate's log is not
-    # up-to-date with the voter's log
+    # up-to-date with the voter's log.
 
     internalError @4 :Text;
     # an internal error occured; a description is included.
   }
+}
+
+struct ClientRequest {
+    entry @0 :Data;
+}
+
+struct ClientResponse {
+    union {
+        success @0 :Void;
+        # The client request succeeded.
+
+        notLeader @1 :Void;
+        # The client request failed because the Raft node is not the leader.
+    }
 }

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -1,0 +1,251 @@
+use std::collections::{hash_map, HashMap, HashSet};
+use std::io;
+use std::net::SocketAddr;
+
+use capnp::{MallocMessageBuilder, MessageBuilder};
+
+use {LogIndex, Term};
+use messages_capnp::{
+    append_entries_request,
+    append_entries_response,
+    client_request,
+    request_vote_request,
+    request_vote_response,
+};
+use state_machine::StateMachine;
+use store::Store;
+
+/// Replicas can be in one of three state:
+///
+/// * `Follower` - which replicates AppendEntries requests and votes for it's leader.
+/// * `Leader` - which leads the cluster by serving incoming requests, ensuring
+///              data is replicated, and issuing heartbeats.
+/// * `Candidate` -  which campaigns in an election and may become a `Leader`
+///                  (if it gets enough votes) or a `Follower`, if it hears from
+///                  a `Leader`.
+#[derive(Clone, Debug)]
+enum ReplicaState {
+    Follower,
+    Candidate(CandidateState),
+    Leader(LeaderState),
+}
+
+#[derive(Clone, Debug)]
+struct LeaderState {
+    last_index: LogIndex,
+    next_index: HashMap<SocketAddr, LogIndex>,
+    match_index: HashMap<SocketAddr, LogIndex>,
+}
+
+impl LeaderState {
+
+    /// Returns a new `LeaderState` struct.
+    ///
+    /// # Arguments
+    ///
+    /// * `last_index` - The index of the leader's most recent log entry at the
+    ///                  time of election.
+    pub fn new(last_index: LogIndex) -> LeaderState {
+        LeaderState {
+            last_index: last_index,
+            next_index: HashMap::new(),
+            match_index: HashMap::new(),
+        }
+    }
+
+    /// Returns the next log entry index of the follower node.
+    pub fn next_index(&mut self, node: SocketAddr) -> LogIndex {
+        match self.next_index.entry(node) {
+            hash_map::Entry::Occupied(entry) => *entry.get(),
+            hash_map::Entry::Vacant(entry) => *entry.insert(self.last_index + 1),
+        }
+    }
+
+    /// Sets the next log entry index of the follower node.
+    pub fn set_next_index(&mut self, node: SocketAddr, index: LogIndex) {
+        self.next_index.insert(node, index);
+    }
+
+    /// Returns the index of the highest log entry known to be replicated on
+    /// the follower node.
+    pub fn match_index(&self, node: SocketAddr) -> LogIndex {
+        *self.match_index.get(&node).unwrap_or(&LogIndex(0))
+    }
+
+    /// Sets the index of the highest log entry known to be replicated on the
+    /// follower node.
+    pub fn set_match_index(&mut self, node: SocketAddr, index: LogIndex) {
+        self.match_index.insert(node, index);
+    }
+
+    /// Counts the number of follower nodes containing the given log index.
+    pub fn count_match_indexes(&self, index: LogIndex) -> usize {
+        self.match_index.values().filter(|&&i| i >= index).count()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CandidateState {
+    granted_votes: usize,
+}
+
+/// A replica of a Raft distributed state machine. A Raft replica controls a client state machine,
+/// to which it applies commands in a globally consistent order.
+struct Replica<S, M> {
+    addr: SocketAddr,
+    peers: HashSet<SocketAddr>,
+
+    store: S,
+    state_machine: M,
+
+    state: ReplicaState,
+    commit_index: LogIndex,
+    last_applied: LogIndex,
+}
+
+impl <S, M> Replica<S, M> where S: Store, M: StateMachine {
+
+    pub fn new(addr: SocketAddr,
+               peers: HashSet<SocketAddr>,
+               store: S,
+               state_machine: M)
+               -> Replica<S, M> {
+        Replica {
+            addr: addr,
+            peers: peers,
+            state: ReplicaState::Follower,
+            store: store,
+            state_machine: state_machine,
+            commit_index: LogIndex(0),
+            last_applied: LogIndex(0),
+        }
+    }
+
+    /// Apply an append entries request to the Raft replica.
+    pub fn append_entries_request(&mut self,
+                                  from: SocketAddr,
+                                  request: append_entries_request::Reader,
+                                  mut response: append_entries_response::Builder) {
+        assert!(self.peers.contains(&from), "Received append entries request from unknown node {}.", from);
+        debug!("ID {}: FROM {} HANDLE append_entries_request", self.addr, from);
+
+        let leader_term = Term(request.get_term());
+        let current_term = self.store.current_term().unwrap();
+
+        if leader_term < current_term {
+            response.set_stale_term(current_term.into());
+            return;
+        }
+
+        match self.state {
+            ReplicaState::Follower => {
+                let prev_log_index = LogIndex(request.get_prev_log_index());
+                let prev_log_term = Term(request.get_prev_log_term());
+
+                let local_latest_index = self.store.latest_index().unwrap();
+                if local_latest_index < prev_log_index {
+                    response.set_inconsistent_prev_entry(());
+                } else {
+                    let (existing_term, _) = self.store.entry(prev_log_index).unwrap();
+                    if existing_term != prev_log_term {
+                        self.store.truncate_entries(prev_log_index).unwrap();
+                        response.set_inconsistent_prev_entry(());
+                    } else {
+                        let entries = request.get_entries().unwrap();
+                        let num_entries = entries.len();
+                        if num_entries > 0 {
+                            let mut entries_vec = Vec::with_capacity(num_entries as usize);
+                            for i in 0..num_entries {
+                                entries_vec.push((leader_term, entries.get(i).unwrap()));
+                            }
+                            self.store.append_entries(prev_log_index + 1, &entries_vec).unwrap();
+                        }
+                        //response.set_success(());
+                    }
+                }
+            },
+            ReplicaState::Candidate(..) | ReplicaState::Leader(..) => {
+                // recognize the new leader, return to follower state, and apply the entries
+                self.state = ReplicaState::Follower;
+                return self.append_entries_request(from, request, response)
+            },
+        }
+    }
+
+    /// Apply an append entries response to the Raft replica.
+    pub fn append_entries_response(&mut self, from: &SocketAddr, response: append_entries_response::Reader) {
+        assert!(self.peers.contains(&from), "Received append entries response from unknown node {}.", from);
+        debug!("ID {}: FROM {} HANDLE append_entries_response", self.addr, from);
+
+        match self.state {
+            ReplicaState::Leader(ref leader_state) => {
+
+            },
+            ReplicaState::Follower | ReplicaState::Candidate(..) => {
+            },
+        }
+
+        match response.which() {
+            Ok(append_entries_response::Success(_)) => {
+            },
+            Ok(append_entries_response::StaleTerm(_)) => {
+            },
+            Ok(append_entries_response::InconsistentPrevEntry(_)) => {
+            },
+            Ok(append_entries_response::InternalError(_)) => {
+            },
+            Err(_) => error!("Append Entries Response type not recognized"),
+        }
+    }
+
+    /// Apply a request vote request to the Raft replica.
+    pub fn request_vote_request(&mut self,
+                                candidate: SocketAddr,
+                                request: request_vote_request::Reader,
+                                mut response: request_vote_response::Builder) {
+        assert!(self.peers.contains(&candidate), "Received request vote request from unknown node {}.", candidate);
+        debug!("ID {}: FROM {} HANDLE request_vote_request", self.addr, candidate);
+        let candidate_term = Term(request.get_term());
+        let candidate_index = LogIndex(request.get_last_log_index());
+        let local_term = self.store.current_term().unwrap();
+        let local_index = self.store.latest_index().unwrap();
+
+        if candidate_term < local_term {
+            response.set_stale_term(local_term.into());
+        } else if candidate_term == local_term && candidate_index < local_index {
+            response.set_inconsistent_log(());
+        } else if candidate_term == local_term && self.store.voted_for().unwrap().is_some() {
+            response.set_already_voted(());
+        } else {
+            if candidate_term != local_term {
+                self.store.set_current_term(candidate_term);
+            }
+            self.store.set_voted_for(Some(candidate));
+            response.set_granted(candidate_term.into());
+        }
+    }
+
+    /// Apply a request vote response to the Raft replica.
+    pub fn request_vote_response(&mut self, from: SocketAddr, response: request_vote_response::Reader) {
+        assert!(self.peers.contains(&from), "Received request vote response from unknown node {}.", from);
+        debug!("ID {}: FROM {} HANDLE request_vote_response", self.addr, from);
+
+    }
+
+    /// Apply a client request to the Raft replica.
+    pub fn client_request(&mut self, from: SocketAddr, request: client_request::Reader) {
+        debug!("ID {}: FROM {} HANDLE client_request", self.addr, from);
+    }
+
+    /// Trigger a timeout on the Raft replica.
+    pub fn timeout(&mut self) {
+        debug!("ID {}: HANDLE timeout", self.addr);
+    }
+
+    /// Get the cluster quorum majority size.
+    fn majority(&self) -> usize {
+        let peers = self.peers.len();
+        let cluster_members = peers.checked_add(1).expect(&format!("unable to support {} cluster members", peers));
+        (cluster_members >> 1) + 1
+    }
+}

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -1,0 +1,75 @@
+use std::{error, io, result};
+use std::fmt::{self, Debug};
+use std::sync::mpsc;
+
+pub trait StateMachine: Debug + Send + 'static {
+
+    type Error: Debug + error::Error + Send + 'static;
+
+    /// Applies a command to the state machine.
+    fn apply(&mut self, command: &[u8]) -> result::Result<(), Self::Error>;
+
+    /// Take a snapshot of the state machine.
+    fn snapshot(&self) -> result::Result<Vec<u8>, Self::Error>;
+
+    /// Restore a snapshot of the state machine.
+    fn restore_snapshot(&mut self, snapshot: Vec<u8>) -> result::Result<(), Self::Error>;
+}
+
+/// A state machine that simply redirects all commands to a channel.
+///
+/// This state machine is chiefly meant for testing.
+pub struct ChannelStateMachine {
+    tx: mpsc::Sender<Vec<u8>>
+}
+impl ChannelStateMachine {
+    pub fn new() -> (ChannelStateMachine, mpsc::Receiver<Vec<u8>>) {
+        let (tx, recv) = mpsc::channel();
+        (ChannelStateMachine { tx: tx }, recv)
+    }
+}
+
+impl StateMachine for ChannelStateMachine {
+
+    type Error = mpsc::SendError<Vec<u8>>;
+
+    fn apply(&mut self, command: &[u8]) -> result::Result<(), mpsc::SendError<Vec<u8>>> {
+        self.tx.send(command.to_vec())
+    }
+
+    fn snapshot(&self) -> result::Result<Vec<u8>, mpsc::SendError<Vec<u8>>> {
+        Ok(Vec::new())
+    }
+
+    fn restore_snapshot(&mut self, _snapshot: Vec<u8>) -> result::Result<(), mpsc::SendError<Vec<u8>>> {
+        Ok(())
+    }
+}
+
+impl Debug for ChannelStateMachine {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "ChannelStateMachine")
+    }
+}
+
+/// A state machine with no states.
+#[derive(Debug)]
+pub struct NullStateMachine;
+
+impl StateMachine for NullStateMachine {
+
+    // The error type is not significant to this state machine
+    type Error = io::Error;
+
+    fn apply(&mut self, _command: &[u8]) -> result::Result<(), io::Error> {
+        Ok(())
+    }
+
+    fn snapshot(&self) -> result::Result<Vec<u8>, io::Error> {
+        Ok(Vec::new())
+    }
+
+    fn restore_snapshot(&mut self, _snapshot: Vec<u8>) -> result::Result<(), io::Error> {
+        Ok(())
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -13,7 +13,7 @@ use Term;
 pub use store::mem::{MemStore, Error};
 
 /// A store of persistent Raft state.
-pub trait Store: Send + Clone + 'static {
+pub trait Store: Clone + Debug + Send + 'static {
 
     type Error: error::Error + Debug + Sized + 'static;
 


### PR DESCRIPTION
This is the initial sketch of the inner-Raft type that is not tied to the networking.  Right now it is called `Replica`, but it can be renamed if we want later.  I'm keeping it in it's own file right now so it won't cause a bunch of conflicts.  I'll be fleshing out more of the methods today by bringing more code over from `RaftNode`.