### PR TITLE
Implement Replica AppendEntries{Request, Response} handling

### DIFF
--- a/src/messages.capnp
+++ b/src/messages.capnp
@@ -30,7 +30,7 @@ struct AppendEntriesRequest {
   # efficiency).
 
   leaderCommit @4 :UInt64;
-  # leader’s commit index.
+  # The Leader’s commit log index.
 }
 
 struct AppendEntriesResponse {
@@ -39,8 +39,9 @@ struct AppendEntriesResponse {
   # The responder's current term.
 
   union {
-    success @1 :Void;
-    # The `AppendEntries` request was a success.
+    success @1 :UInt64;
+    # The `AppendEntries` request was a success. The responder's latest log
+    # index is returned.
 
     staleTerm @2 :Void;
     # The `AppendEntries` request failed because the follower has a greater term

--- a/src/node.rs
+++ b/src/node.rs
@@ -187,7 +187,9 @@ impl RaftConnection {
             // We won't be responding. This is already a response.
             match response.which().unwrap() {
                 rpc_response::Which::AppendEntries(Ok(call)) => {
-                    replica.append_entries_response(from, call);
+                    let res = message.init_root::<append_entries_request::Builder>();
+                    let send_message = replica.append_entries_response(from, call, res);
+                    // TODO: send the AppendEntries requests if necessary
                     Ok(())
                 },
                 rpc_response::Which::RequestVote(Ok(call)) => {

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -100,11 +100,6 @@ impl Store for MemStore {
         self.entries.truncate(Into::<u64>::into(from) as usize - 1);
         Ok(self.entries.extend(entries.iter().map(|&(term, command)| (term, command.to_vec()))))
     }
-
-    fn truncate_entries(&mut self, index: LogIndex) -> result::Result<(), Error> {
-        assert!(self.latest_log_index().unwrap() >= index);
-        Ok(self.entries.truncate(Into::<u64>::into(index) as usize - 1))
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Testing of AppendEntries is blocked on implementing heartbeat timeouts and client requests.