### PR TITLE
introduce message wrapper, cleanup client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ build = "build.rs"
 git = "https://github.com/dwrensha/capnpc-rust"
 
 [dependencies]
+log = "*"
+rand = "*"
 rustc-serialize = "*"
 uuid = "*"
-rand = "*"
-log = "*"
 
 [dependencies.capnp]
 git = "https://github.com/dwrensha/capnproto-rust"

--- a/src/messages.capnp
+++ b/src/messages.capnp
@@ -1,16 +1,13 @@
 @0xbdca3d7c76dab735;
 
-struct RpcRequest {
+struct Message {
     union {
-        appendEntries @0 :AppendEntriesRequest;
-        requestVote @1 :RequestVoteRequest;
-    }
-}
-
-struct RpcResponse {
-    union {
-        appendEntries @0 :AppendEntriesResponse;
-        requestVote @1 :RequestVoteResponse;
+        appendEntriesRequest @0 :AppendEntriesRequest;
+        appendEntriesResponse @1 :AppendEntriesResponse;
+        requestVoteResponse @2 :RequestVoteResponse;
+        requestVoteRequest @3 :RequestVoteRequest;
+        clientAppendRequest @4 :ClientAppendRequest;
+        clientAppendResponse @5 :ClientAppendResponse;
     }
 }
 
@@ -90,30 +87,26 @@ struct RequestVoteResponse {
     # up-to-date with the voter's log.
 
     internalError @5 :Text;
-    # an internal error occured; a description is included.
+    # An internal error occured; a description is included.
   }
 }
 
-struct ClientRequest {
-    union {
-        append @0 :Data;
-        # An entry to append.
-
-        die @1 :Text;
-        # Die order, include a reason when killing. Mostly for testing.
-
-        leaderRefresh @2 :Void;
-        # Requests a current pointer to the leader. Expect a `notLeader` response.
-    }
+struct ClientAppendRequest {
+    entry @0 :Data;
+    # An entry to append.
 }
 
-struct ClientResponse {
+struct ClientAppendResponse {
     union {
         success @0 :Void;
         # The client request succeeded.
 
-        notLeader @1 :Text;
+        unknownLeader @1 :Void;
+        # The client request failed because the Raft node is not the leader,
+        # and does not know who the leader is.
+
+        notLeader @2 :Text;
         # The client request failed because the Raft node is not the leader.
-        # The value returned is the address of the leader.
+        # The value returned may be the address of the current leader.
     }
 }

--- a/tests/hello.rs
+++ b/tests/hello.rs
@@ -4,17 +4,12 @@ mod new;
 
 use new::new_cluster;
 
-
 #[test]
 fn hello() {
     env_logger::init().unwrap();
     let mut nodes = new_cluster(3);
     let sent_command = b"Hello";
-    // Push
-    nodes[0].0.append(sent_command)
-        .ok().expect("Couldn't append.");
-    // Retrieve.
-    let received_command = nodes[0].1.recv()
-        .ok().expect("Couldn't recv.");
-    assert_eq!(received_command, sent_command);
+    nodes[0].0.append(sent_command).unwrap();
+    let recieved_command = nodes[0].1.recv().unwrap();
+    assert_eq!(recieved_command, sent_command);
 }

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -15,11 +15,9 @@ pub fn new_cluster(size: u16) -> Vec<(Raft, mpsc::Receiver<Vec<u8>>)> {
         (0..size).map(|port| FromStr::from_str(&format!("127.0.0.1:200{}", port)).unwrap()).collect();
 
     addrs.iter().map(|addr| {
-        let mut peers = addrs.clone();
-        peers.remove(addr);
         let store = MemStore::new();
         let (state_machine, recv) = ChannelStateMachine::new();
         println!("Spawning new Raft on {}", addr);
-        (Raft::new(addr.clone(), peers, store, state_machine), recv)
+        (Raft::new(addr.clone(), addrs.clone(), store, state_machine), recv)
     }).collect()
 }


### PR DESCRIPTION
This commit introduces a wrapper message type, `Message`, which all
messages sent between Raft clients and servers should use to wrap the
message type.  Additionally, the client has been reduced to just the
append method. Leader refresh was removed because it's impossible to
provide correctly, and die was removed because its uneeded right now,
and in the long run shutdown should probably be provided by the server
objects, not the rpc system.