### PR TITLE
remove or document all uses of unwrap in raft::Server.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,18 +51,6 @@ extern crate rand;
 extern crate uuid;
 #[macro_use] extern crate log;
 
-/// Unwraps the Result value, or logs a warning and returns early if the value
-/// is an `Err`.
-macro_rules! try_warn {
-    ($expr:expr, $($arg:tt)*) => (match $expr {
-        ::std::result::Result::Ok(val) => val,
-        ::std::result::Result::Err(err) => {
-            warn!($($arg)*, err);
-            return ::std::result::Result::Err(::std::convert::From::from(err));
-        },
-    })
-}
-
 pub mod state_machine;
 pub mod store;
 
@@ -107,10 +95,13 @@ pub enum Error {
 /// * `ConnectionLimitReached` - The server tried to open a new connection (to a peer or a client),
 ///                              but the maximum number of connections was already open.
 /// * `InvalidClientId` - A client reported an invalid client id.
+/// * `InvalidConnectionType` - A remote connection attempted to use an unknown connection type in
+///                             the connection preamble.
 #[derive(Debug)]
 pub enum ErrorKind {
     ConnectionLimitReached,
     InvalidClientId,
+    UnknownConnectionType,
 }
 
 impl From<io::Error> for Error {


### PR DESCRIPTION
Most uses of panicking functions (`unwrap` and `expect`) have been
removed, except in a few documented places. With this commit the story
around error handling in server.rs is complete using the following
guidelines:

  * Operations that are not expected to fail should use a
    call to `assert!`, `unwrap!`, `expect`, or a indexing operator.
    These calls should be documented with either a comment, or
    a message that will be included in the panic. Panicking in these
    scenarios ensures that if program invariants are broken the
    server will immediately crash instead of continuing and potentially
    comprimising safety.

  * Operations that may fail during normal operation (connections,
    deserialization) use non-panicking error handling (`try!`, or
    ignoring the failure with a warn-level log message). When an
    operation on a connection fails, that connection is *always* reset.
    Reseting a client connection means simply dropping it. Reseting a
    peer connection means closing the current TCP socket, waiting for
    reconnection period (currently determined via exponential-backoff
    with jitter), and then attempting to reconnect. If a peer server
    connects to the server, the current connection to that peer is
    replaced with the new one. This ensures that only a single TCP
    connection is open to a peer at a time.