### PR TITLE
Refactored errors with wrapped_enum and removed token from Connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ log = "*"
 rand = "*"
 uuid = "*"
 bufstream = "*"
+wrapped_enum = "*"
 
 [dependencies.capnp]
 git = "https://github.com/danburkert/capnproto-rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ extern crate mio;
 extern crate rand;
 extern crate uuid;
 #[macro_use] extern crate log;
+#[macro_use] extern crate wrapped_enum;
 
 pub mod state_machine;
 pub mod store;
@@ -82,44 +83,30 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// With the exception of the `Raft` variant these are generated from `try!()` macros invoking
 /// on `io::Error` or `capnp::Error` by using
 /// [`FromError`](https://doc.rust-lang.org/std/error/#the-fromerror-trait).
-#[derive(Debug)]
-pub enum Error {
-    CapnProto(capnp::Error),
-    SchemaError(capnp::NotInSchema),
-    Io(io::Error),
-    Raft(ErrorKind),
+wrapped_enum!{
+    #[derive(Debug)]
+    ///
+    pub enum Error {
+        ///
+        CapnProto(capnp::Error),
+        ///
+        SchemaError(capnp::NotInSchema),
+        ///
+        Io(io::Error),
+        ///
+        Raft(ErrorKind),
+    }
 }
 
-/// Currently, this can only be:
+#[derive(Debug)]
 ///
-/// * `ConnectionLimitReached` - The server tried to open a new connection (to a peer or a client),
-///                              but the maximum number of connections was already open.
-/// * `InvalidClientId` - A client reported an invalid client id.
-/// * `InvalidConnectionType` - A remote connection attempted to use an unknown connection type in
-///                             the connection preamble.
-#[derive(Debug)]
 pub enum ErrorKind {
+    /// The server ran out of slots in the slab for new connections
     ConnectionLimitReached,
+    /// A client reported an invalid client id
     InvalidClientId,
+    /// A remote connection attemtped to use an unknown connection type in the connection preamble
     UnknownConnectionType,
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Error {
-        Error::Io(err)
-    }
-}
-
-impl From<capnp::Error> for Error {
-    fn from(err: capnp::Error) -> Error {
-        Error::CapnProto(err)
-    }
-}
-
-impl From<capnp::NotInSchema> for Error {
-    fn from(err: capnp::NotInSchema) -> Error {
-        Error::SchemaError(err)
-    }
 }
 
 impl fmt::Display for Error {

--- a/src/server.rs
+++ b/src/server.rs
@@ -106,9 +106,8 @@ impl<S, M> Server<S, M> where S: Store, M: StateMachine {
             assert!(server.peer_tokens.insert(peer_id, token).is_none());
 
             let mut connection = &mut server.connections[token];
-            connection.set_token(token);
             connection.send_message(messages::server_connection_preamble(id));
-            try!(connection.register(&mut event_loop));
+            try!(connection.register(&mut event_loop, token));
         }
 
         Ok((server, event_loop))
@@ -214,11 +213,10 @@ impl<S, M> Server<S, M> where S: Store, M: StateMachine {
         match kind {
             ConnectionKind::Peer(..) => {
                 // Crash if reseting the connection fails.
-                let (duration, timeout, handle) = self.connections[token].reset_peer(event_loop)
-                                                      .unwrap();
+                let (timeout, handle) = self.connections[token]
+                                            .reset_peer(event_loop, token)
+                                            .unwrap();
 
-                info!("{:?}: {:?} reset, will attempt to reconnect in {}ms", self,
-                      &self.connections[token], duration);
                 assert!(self.reconnection_timeouts.insert(token, handle).is_none(),
                         "raft::{:?}: timeout already registered: {:?}", self, timeout);
             },
@@ -348,18 +346,14 @@ impl<S, M> Handler for Server<S, M> where S: Store, M: StateMachine {
                             .insert(connection)
                             .map_err(|_| Error::Raft(ErrorKind::ConnectionLimitReached))
                     })
-                    .and_then(|token| {
-                        let mut connection = &mut self.connections[token];
-                        connection.set_token(token);
-                        connection.register(event_loop)
-                    })
+                    .and_then(|token| self.connections[token].register(event_loop, token))
                     .unwrap_or_else(|error| warn!("{:?}: unable to accept connection: {}",
                                                   self, error));
             } else {
                 self.readable(event_loop, token)
                     // Only reregister the connection with the event loop if no
                     // error occurs and the connection is *not* reset.
-                    .and_then(|_| self.connections[token].reregister(event_loop))
+                    .and_then(|_| self.connections[token].reregister(event_loop, token))
                     .unwrap_or_else(|error| {
                         warn!("{:?}: unable to read message from connection {:?}: {}",
                               self, self.connections[token], error);
@@ -385,7 +379,7 @@ impl<S, M> Handler for Server<S, M> where S: Store, M: StateMachine {
                         "raft::{:?}: missing timeout: {:?}", self, timeout);
                 self.connections[token]
                     .reconnect_peer(self.id)
-                    .and_then(|_| self.connections[token].reregister(event_loop))
+                    .and_then(|_| self.connections[token].reregister(event_loop, token))
                     .unwrap_or_else(|error| {
                         warn!("{:?}: unable to reconnect connection {:?}: {}",
                               self, &self.connections[token], error);
@@ -398,7 +392,7 @@ impl<S, M> Handler for Server<S, M> where S: Store, M: StateMachine {
 
 impl <S, M> fmt::Debug for Server<S, M> where S: Store, M: StateMachine {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "Server({})", self.id)
+        fmt::Debug::fmt(&self.id, fmt)
     }
 }
 


### PR DESCRIPTION
Stripped down #36.

Despite being a stripped down version of the above, there have still been a few more changes.