### PR TITLE
change uses of  log scoping in tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,21 @@ extern crate uuid;
 #[macro_use] extern crate scoped_log;
 #[macro_use] extern crate wrapped_enum;
 
+#[cfg(test)]
+extern crate env_logger;
+
+/// Prepares the environment testing. Should be called as the first line of every test with the
+/// name of the test as the only argument.
+///
+/// TODO: Make this an annotation like #[rust_test] instead of a macro.
+#[cfg(test)]
+macro_rules! setup_test {
+    ($test_name:expr) => (
+        let _ = env_logger::init();
+        push_log_scope!($test_name);
+    );
+}
+
 pub mod state_machine;
 pub mod store;
 

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -664,6 +664,8 @@ impl <S, M> fmt::Debug for Replica<S, M> where S: Store, M: StateMachine {
 #[cfg(test)]
 mod test {
 
+    extern crate env_logger;
+
     use std::collections::{HashSet, HashMap};
     use std::io::Cursor;
     use std::rc::Rc;
@@ -739,6 +741,7 @@ mod test {
     /// The single replica should transition straight to the Leader state upon the first timeout.
     #[test]
     fn test_solitary_replica_transition_to_leader() {
+        setup_test!("test_solitary_replica_transition_to_leader");
         let (_, mut replica) = new_cluster(1).into_iter().next().unwrap();
         assert!(replica.is_follower());
 
@@ -753,6 +756,7 @@ mod test {
     /// A simple election test of a two-replica cluster.
     #[test]
     fn test_election_2() {
+        setup_test!("test_election_2");
         let mut replicas = new_cluster(2);
         let replica_ids: Vec<ServerId> = replicas.keys().cloned().collect();
         let leader = &replica_ids[0];
@@ -766,6 +770,7 @@ mod test {
     /// A simple election test of a three-replica cluster.
     #[test]
     fn test_election_3() {
+        setup_test!("test_election_3");
         let mut replicas = new_cluster(3);
         let replica_ids: Vec<ServerId> = replicas.keys().cloned().collect();
         let leader = &replica_ids[0];
@@ -779,6 +784,7 @@ mod test {
     /// A simple election test of a five-replica cluster.
     #[test]
     fn test_election_5() {
+        setup_test!("test_election_5");
         let mut replicas = new_cluster(5);
         let replica_ids: Vec<ServerId> = replicas.keys().cloned().collect();
         let leader = &replica_ids[0];
@@ -794,6 +800,7 @@ mod test {
     /// A simple election test of a six-replica cluster.
     #[test]
     fn test_election_6() {
+        setup_test!("test_election_6");
         let mut replicas = new_cluster(6);
         let replica_ids: Vec<ServerId> = replicas.keys().cloned().collect();
         let leader = &replica_ids[0];
@@ -810,6 +817,7 @@ mod test {
     /// A simple election test of a seven-replica cluster.
     #[test]
     fn test_election_7() {
+        setup_test!("test_election_7");
         let mut replicas = new_cluster(7);
         let replica_ids: Vec<ServerId> = replicas.keys().cloned().collect();
         let leader = &replica_ids[0];
@@ -830,6 +838,7 @@ mod test {
     /// leader.
     #[test]
     fn test_heartbeat() {
+        setup_test!("test_heartbeat");
         let mut replicas = new_cluster(2);
         let replica_ids: Vec<ServerId> = replicas.keys().cloned().collect();
         let leader_id = &replica_ids[0];

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -730,8 +730,8 @@ mod test {
         let mut actions = Actions::new();
         replicas.get_mut(&leader).unwrap().election_timeout(&mut actions);
         let client_messages = apply_actions(leader, actions, replicas);
-        scoped_assert!(client_messages.is_empty());
-        scoped_assert!(replicas[&leader].is_leader());
+        assert!(client_messages.is_empty());
+        assert!(replicas[&leader].is_leader());
     }
 
     /// Tests that a single-replica cluster will behave appropriately.
@@ -740,14 +740,14 @@ mod test {
     #[test]
     fn test_solitary_replica_transition_to_leader() {
         let (_, mut replica) = new_cluster(1).into_iter().next().unwrap();
-        scoped_assert!(replica.is_follower());
+        assert!(replica.is_follower());
 
         let mut actions = Actions::new();
         replica.election_timeout(&mut actions);
-        scoped_assert!(replica.is_leader());
-        scoped_assert!(actions.peer_messages.is_empty());
-        scoped_assert!(actions.client_messages.is_empty());
-        scoped_assert!(actions.timeouts.is_empty());
+        assert!(replica.is_leader());
+        assert!(actions.peer_messages.is_empty());
+        assert!(actions.client_messages.is_empty());
+        assert!(actions.timeouts.is_empty());
     }
 
     /// A simple election test of a two-replica cluster.
@@ -759,8 +759,8 @@ mod test {
         let follower = &replica_ids[1];
         elect_leader(leader.clone(), &mut replicas);
 
-        scoped_assert!(replicas[leader].is_leader());
-        scoped_assert!(replicas[follower].is_follower());
+        assert!(replicas[leader].is_leader());
+        assert!(replicas[follower].is_follower());
     }
 
     /// A simple election test of a three-replica cluster.
@@ -771,9 +771,9 @@ mod test {
         let leader = &replica_ids[0];
         elect_leader(leader.clone(), &mut replicas);
 
-        scoped_assert!(replicas[leader].is_leader());
-        scoped_assert!(replicas[&replica_ids[1]].is_follower());
-        scoped_assert!(replicas[&replica_ids[2]].is_follower());
+        assert!(replicas[leader].is_leader());
+        assert!(replicas[&replica_ids[1]].is_follower());
+        assert!(replicas[&replica_ids[2]].is_follower());
     }
 
     /// A simple election test of a five-replica cluster.
@@ -784,11 +784,11 @@ mod test {
         let leader = &replica_ids[0];
         elect_leader(leader.clone(), &mut replicas);
 
-        scoped_assert!(replicas[leader].is_leader());
-        scoped_assert!(replicas[&replica_ids[1]].is_follower());
-        scoped_assert!(replicas[&replica_ids[2]].is_follower());
-        scoped_assert!(replicas[&replica_ids[3]].is_follower());
-        scoped_assert!(replicas[&replica_ids[4]].is_follower());
+        assert!(replicas[leader].is_leader());
+        assert!(replicas[&replica_ids[1]].is_follower());
+        assert!(replicas[&replica_ids[2]].is_follower());
+        assert!(replicas[&replica_ids[3]].is_follower());
+        assert!(replicas[&replica_ids[4]].is_follower());
     }
 
     /// A simple election test of a six-replica cluster.
@@ -799,12 +799,12 @@ mod test {
         let leader = &replica_ids[0];
         elect_leader(leader.clone(), &mut replicas);
 
-        scoped_assert!(replicas[leader].is_leader());
-        scoped_assert!(replicas[&replica_ids[1]].is_follower());
-        scoped_assert!(replicas[&replica_ids[2]].is_follower());
-        scoped_assert!(replicas[&replica_ids[3]].is_follower());
-        scoped_assert!(replicas[&replica_ids[4]].is_follower());
-        scoped_assert!(replicas[&replica_ids[5]].is_follower());
+        assert!(replicas[leader].is_leader());
+        assert!(replicas[&replica_ids[1]].is_follower());
+        assert!(replicas[&replica_ids[2]].is_follower());
+        assert!(replicas[&replica_ids[3]].is_follower());
+        assert!(replicas[&replica_ids[4]].is_follower());
+        assert!(replicas[&replica_ids[5]].is_follower());
     }
 
     /// A simple election test of a seven-replica cluster.
@@ -815,13 +815,13 @@ mod test {
         let leader = &replica_ids[0];
         elect_leader(leader.clone(), &mut replicas);
 
-        scoped_assert!(replicas[leader].is_leader());
-        scoped_assert!(replicas[&replica_ids[1]].is_follower());
-        scoped_assert!(replicas[&replica_ids[2]].is_follower());
-        scoped_assert!(replicas[&replica_ids[3]].is_follower());
-        scoped_assert!(replicas[&replica_ids[4]].is_follower());
-        scoped_assert!(replicas[&replica_ids[5]].is_follower());
-        scoped_assert!(replicas[&replica_ids[6]].is_follower());
+        assert!(replicas[leader].is_leader());
+        assert!(replicas[&replica_ids[1]].is_follower());
+        assert!(replicas[&replica_ids[2]].is_follower());
+        assert!(replicas[&replica_ids[3]].is_follower());
+        assert!(replicas[&replica_ids[4]].is_follower());
+        assert!(replicas[&replica_ids[5]].is_follower());
+        assert!(replicas[&replica_ids[6]].is_follower());
     }
 
     /// Tests the Raft heartbeating mechanism. The leader receives a heartbeat

--- a/src/server.rs
+++ b/src/server.rs
@@ -501,7 +501,7 @@ mod test {
     /// Tests that a Server will reject an invalid peer configuration set.
     #[test]
     fn test_illegal_peer_set() {
-        let _ = env_logger::init();
+        setup_test!("test_illegal_peer_set");
         let peer_id = ServerId::from(0);
         let mut peers = HashMap::new();
         peers.insert(peer_id, SocketAddr::from_str("127.0.0.1:0").unwrap());
@@ -512,7 +512,7 @@ mod test {
     /// connection is droped.
     #[test]
     fn test_peer_connect() {
-        let _ = env_logger::init();
+        setup_test!("test_peer_connect");
         let peer_id = ServerId::from(1);
 
         let peer_listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -550,7 +550,7 @@ mod test {
     /// connects through another TCP connection.
     #[test]
     fn test_peer_accept() {
-        let _ = env_logger::init();
+        setup_test!("test_peer_accept");
         let peer_id = ServerId::from(1);
 
         let peer_listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -586,7 +586,7 @@ mod test {
     /// it when the client disconnects.
     #[test]
     fn test_client_accept() {
-        let _ = env_logger::init();
+        setup_test!("test_client_accept");
 
         let (mut server, mut event_loop) = new_test_server(HashMap::new()).unwrap();
 
@@ -616,7 +616,7 @@ mod test {
     /// send a preamble.
     #[test]
     fn test_invalid_accept() {
-        let _ = env_logger::init();
+        setup_test!("test_invalid_accept");
 
         let (mut server, mut event_loop) = new_test_server(HashMap::new()).unwrap();
 
@@ -637,7 +637,7 @@ mod test {
     /// message is received.
     #[test]
     fn test_invalid_peer_message() {
-        let _ = env_logger::init();
+        setup_test!("test_invalid_peer_message");
 
         let peer_id = ServerId::from(1);
 
@@ -666,7 +666,7 @@ mod test {
     /// message is received.
     #[test]
     fn test_invalid_client_message() {
-        let _ = env_logger::init();
+        setup_test!("test_invalid_client_message");
 
         let (mut server, mut event_loop) = new_test_server(HashMap::new()).unwrap();
 
@@ -697,7 +697,7 @@ mod test {
     /// after failing to connect at startup.
     #[test]
     fn test_unreachable_peer_reconnect() {
-        let _ = env_logger::init();
+        setup_test!("test_unreachable_peer_reconnect");
         let peer_id = ServerId::from(1);
         let mut peers = HashMap::new();
         peers.insert(peer_id, get_unbound_address());

--- a/src/server.rs
+++ b/src/server.rs
@@ -109,7 +109,7 @@ impl<S, M> Server<S, M> where S: Store, M: StateMachine {
             let token: Token = try!(server.connections
                                           .insert(try!(Connection::peer(peer_id, peer_addr)))
                                           .map_err(|_| Error::Raft(ErrorKind::ConnectionLimitReached)));
-            scoped_assert!(server.peer_tokens.insert(peer_id, token).is_none());
+            assert!(server.peer_tokens.insert(peer_id, token).is_none());
 
             let mut connection = &mut server.connections[token];
             connection.send_message(messages::server_connection_preamble(id));
@@ -188,7 +188,7 @@ impl<S, M> Server<S, M> where S: Store, M: StateMachine {
         }
         if clear_timeouts {
             for (timeout, &handle) in &self.replica_timeouts {
-                scoped_assert!(event_loop.clear_timeout(handle),
+                assert!(event_loop.clear_timeout(handle),
                                "unable to clear timeout: {:?}", timeout);
             }
             self.replica_timeouts.clear();
@@ -505,7 +505,7 @@ mod test {
         let peer_id = ServerId::from(0);
         let mut peers = HashMap::new();
         peers.insert(peer_id, SocketAddr::from_str("127.0.0.1:0").unwrap());
-        scoped_assert!(new_test_server(peers).is_err());
+        assert!(new_test_server(peers).is_err());
     }
 
     /// Tests that a Server connects to peer at startup, and reconnects when the
@@ -527,23 +527,23 @@ mod test {
         // Check that the server sends a valid preamble.
         event_loop.run_once(&mut server).unwrap();
         assert_eq!(ServerId::from(0), read_server_preamble(&mut stream));
-        scoped_assert!(peer_connected(&server, peer_id));
+        assert!(peer_connected(&server, peer_id));
 
         // Drop the connection.
         drop(stream);
         event_loop.run_once(&mut server).unwrap();
-        scoped_assert!(!peer_connected(&server, peer_id));
+        assert!(!peer_connected(&server, peer_id));
 
         // Check that the server reconnects after a timeout.
         event_loop.run_once(&mut server).unwrap();
-        scoped_assert!(peer_connected(&server, peer_id));
+        assert!(peer_connected(&server, peer_id));
         let (mut stream, _)  = peer_listener.accept().unwrap();
 
         // Check that the server sends a valid preamble after the connection is
         // established.
         event_loop.run_once(&mut server).unwrap();
         assert_eq!(ServerId::from(0), read_server_preamble(&mut stream));
-        scoped_assert!(peer_connected(&server, peer_id));
+        assert!(peer_connected(&server, peer_id));
     }
 
     /// Tests that a Server will replace a peer's TCP connection if the peer
@@ -565,7 +565,7 @@ mod test {
         // Check that the server sends a valid preamble.
         event_loop.run_once(&mut server).unwrap();
         assert_eq!(ServerId::from(0), read_server_preamble(&mut in_stream));
-        scoped_assert!(peer_connected(&server, peer_id));
+        assert!(peer_connected(&server, peer_id));
 
         let server_addr = server.listener.local_addr().unwrap();
 
@@ -579,7 +579,7 @@ mod test {
         event_loop.run_once(&mut server).unwrap();
 
         // Check that the server has closed the old connection.
-        scoped_assert!(stream_shutdown(&mut in_stream));
+        assert!(stream_shutdown(&mut in_stream));
     }
 
     /// Tests that the server will accept a client connection, then dispose of
@@ -603,13 +603,13 @@ mod test {
         event_loop.run_once(&mut server).unwrap();
 
         // Check that the server holds on to the client connection.
-        scoped_assert!(client_connected(&server, client_id));
+        assert!(client_connected(&server, client_id));
 
         // Check that the server disposes of the client connection when the TCP
         // stream is dropped.
         drop(stream);
         event_loop.run_once(&mut server).unwrap();
-        scoped_assert!(!client_connected(&server, client_id));
+        assert!(!client_connected(&server, client_id));
     }
 
     /// Tests that the server will throw away connections that do not properly
@@ -630,7 +630,7 @@ mod test {
         event_loop.run_once(&mut server).unwrap();
 
         // Check that the server disposes of the connection.
-        scoped_assert!(stream_shutdown(&mut stream));
+        assert!(stream_shutdown(&mut stream));
     }
 
     /// Tests that the server will reset a peer connection when an invalid
@@ -655,11 +655,11 @@ mod test {
         event_loop.run_once(&mut server).unwrap();
 
         // Check that the server resets the connection.
-        scoped_assert!(!peer_connected(&server, peer_id));
+        assert!(!peer_connected(&server, peer_id));
 
         // Check that the server reconnects after a timeout.
         event_loop.run_once(&mut server).unwrap();
-        scoped_assert!(peer_connected(&server, peer_id));
+        assert!(peer_connected(&server, peer_id));
     }
 
     /// Tests that the server will reset a client connection when an invalid
@@ -683,14 +683,14 @@ mod test {
         event_loop.run_once(&mut server).unwrap();
 
         // Check that the server holds on to the client connection.
-        scoped_assert!(client_connected(&server, client_id));
+        assert!(client_connected(&server, client_id));
 
         // Send an invalid client message to the server.
         stream.write(b"foo bar baz").unwrap();
         event_loop.run_once(&mut server).unwrap();
 
         // Check that the server disposes of the client connection.
-        scoped_assert!(!client_connected(&server, client_id));
+        assert!(!client_connected(&server, client_id));
     }
 
     /// Tests that a Server will attempt to reconnect to an unreachable peer
@@ -707,14 +707,14 @@ mod test {
 
         // Error event for the peer connection; connection is reset.
         event_loop.run_once(&mut server).unwrap();
-        scoped_assert!(!peer_connected(&mut server, peer_id));
+        assert!(!peer_connected(&mut server, peer_id));
 
         // Reconnection timeout fires and connection stream is recreated.
         event_loop.run_once(&mut server).unwrap();
-        scoped_assert!(peer_connected(&mut server, peer_id));
+        assert!(peer_connected(&mut server, peer_id));
 
         // Error event for the new peer connection; connection is reset.
         event_loop.run_once(&mut server).unwrap();
-        scoped_assert!(!peer_connected(&mut server, peer_id));
+        assert!(!peer_connected(&mut server, peer_id));
     }
 }


### PR DESCRIPTION
This commits remove uses of `scoped_assert!` in tests and introduce test-specific log scopes.  See the commit messages for reasoning.

cc @james-darkfox 