### PR TITLE
Initial Benchmarks

### DIFF
--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -58,7 +58,7 @@ impl Backoff {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     use super::*;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -123,7 +123,7 @@ impl fmt::Debug for Client {
 
 
 #[cfg(test)]
-mod test {
+mod tests {
     extern crate env_logger;
 
     use std::collections::HashSet;

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -756,9 +756,10 @@ impl <L, M> fmt::Debug for Consensus<L, M> where L: Log, M: StateMachine {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     extern crate env_logger;
+    extern crate test;
 
     use std::collections::{HashMap, VecDeque};
     use std::io::Cursor;
@@ -768,6 +769,7 @@ mod test {
 
     use capnp::{MallocMessageBuilder, MessageBuilder, ReaderOptions};
     use capnp::serialize::{self, OwnedSpaceMessageReader};
+    use test::Bencher;
 
     use ClientId;
     use LogIndex;
@@ -1006,5 +1008,144 @@ mod test {
                 assert_eq!((Term(1), value), module.persistent_log.entry(LogIndex(1)).unwrap());
             }
         }
+    }
+
+    #[bench]
+    fn bench_proposal_1(b: &mut Bencher) {
+        scoped_debug!("benching size {} cluster", 1);
+        b.iter(|| {
+            let mut consensus_modules = new_cluster(1);
+            let module_ids: Vec<ServerId> = consensus_modules.keys().cloned().collect();
+            let leader = module_ids[0];
+            elect_leader(leader, &mut consensus_modules);
+
+            let value: &[u8] = b"foo";
+            let proposal = into_reader(&messages::proposal_request(value));
+            let mut actions = Actions::new();
+
+            let client = ClientId::new();
+
+            consensus_modules.get_mut(&leader)
+                    .unwrap()
+                    .apply_client_message(client, &proposal, &mut actions);
+
+            let client_messages = apply_actions(leader, actions, &mut consensus_modules);
+            assert_eq!(1, client_messages.len());
+            for module in consensus_modules.values() {
+                assert_eq!((Term(1), value), module.persistent_log.entry(LogIndex(1)).unwrap());
+            }
+        })
+    }
+
+    #[bench]
+    fn bench_proposal_7(b: &mut Bencher) {
+        scoped_debug!("benching size {} cluster", 7);
+        b.iter(|| {
+            let mut consensus_modules = new_cluster(7);
+            let module_ids: Vec<ServerId> = consensus_modules.keys().cloned().collect();
+            let leader = module_ids[0];
+            elect_leader(leader, &mut consensus_modules);
+
+            let value: &[u8] = b"foo";
+            let proposal = into_reader(&messages::proposal_request(value));
+            let mut actions = Actions::new();
+
+            let client = ClientId::new();
+
+            consensus_modules.get_mut(&leader)
+                    .unwrap()
+                    .apply_client_message(client, &proposal, &mut actions);
+
+            let client_messages = apply_actions(leader, actions, &mut consensus_modules);
+            assert_eq!(1, client_messages.len());
+            for module in consensus_modules.values() {
+                assert_eq!((Term(1), value), module.persistent_log.entry(LogIndex(1)).unwrap());
+            }
+        })
+    }
+
+    /// Tests that a client query is correctly responded to, and the client is notified
+    /// of the success.
+    #[test]
+    fn test_query() {
+        setup_test!("test_query");
+        // Test various sizes.
+        for i in 1..7 {
+            scoped_debug!("testing size {} cluster", i);
+            let mut consensus_modules = new_cluster(i);
+            let module_ids: Vec<ServerId> = consensus_modules.keys().cloned().collect();
+            let leader = module_ids[0];
+            elect_leader(leader, &mut consensus_modules);
+
+            let value: &[u8] = b"foo";
+            let query = into_reader(&messages::proposal_request(value));
+            let mut actions = Actions::new();
+
+            let client = ClientId::new();
+
+            consensus_modules.get_mut(&leader)
+                    .unwrap()
+                    .apply_client_message(client, &query, &mut actions);
+
+            let client_messages = apply_actions(leader, actions, &mut consensus_modules);
+            assert_eq!(1, client_messages.len());
+            for module in consensus_modules.values() {
+                assert_eq!((Term(1), value), module.persistent_log.entry(LogIndex(1)).unwrap());
+            }
+        }
+    }
+
+    #[bench]
+    fn bench_query_1(b: &mut Bencher) {
+        scoped_debug!("benching size {} cluster", 1);
+        b.iter(|| {
+            let mut consensus_modules = new_cluster(1);
+            let module_ids: Vec<ServerId> = consensus_modules.keys().cloned().collect();
+            let leader = module_ids[0];
+            elect_leader(leader, &mut consensus_modules);
+
+            let value: &[u8] = b"foo";
+            let query = into_reader(&messages::proposal_request(value));
+            let mut actions = Actions::new();
+
+            let client = ClientId::new();
+
+            consensus_modules.get_mut(&leader)
+                    .unwrap()
+                    .apply_client_message(client, &query, &mut actions);
+
+            let client_messages = apply_actions(leader, actions, &mut consensus_modules);
+            assert_eq!(1, client_messages.len());
+            for module in consensus_modules.values() {
+                assert_eq!((Term(1), value), module.persistent_log.entry(LogIndex(1)).unwrap());
+            }
+        })
+    }
+
+    #[bench]
+    fn bench_query_7(b: &mut Bencher) {
+        scoped_debug!("benching size {} cluster", 7);
+        b.iter(|| {
+            let mut consensus_modules = new_cluster(7);
+            let module_ids: Vec<ServerId> = consensus_modules.keys().cloned().collect();
+            let leader = module_ids[0];
+            elect_leader(leader, &mut consensus_modules);
+
+            let value: &[u8] = b"foo";
+            let query = into_reader(&messages::proposal_request(value));
+            let mut actions = Actions::new();
+
+            let client = ClientId::new();
+
+            consensus_modules.get_mut(&leader)
+                    .unwrap()
+                    .apply_client_message(client, &query, &mut actions);
+
+            let client_messages = apply_actions(leader, actions, &mut consensus_modules);
+            assert_eq!(1, client_messages.len());
+            for module in consensus_modules.values() {
+                assert_eq!((Term(1), value), module.persistent_log.entry(LogIndex(1)).unwrap());
+            }
+        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/Hoverbear/raft/master/raft.png")]
 #![doc(html_root_url = "https://hoverbear.github.io/raft/raft/")]
 
+#![feature(test)]
+
 //! This is the Raft Distributed Consensus Protocol implemented for Rust.
 //! [Raft](http://raftconsensus.github.io/) is described as:
 //!
@@ -49,6 +51,7 @@ extern crate capnp;
 extern crate mio;
 extern crate rand;
 extern crate uuid;
+extern crate test;
 #[macro_use] extern crate log;
 #[macro_use] extern crate scoped_log;
 #[macro_use] extern crate wrapped_enum;

--- a/src/server.rs
+++ b/src/server.rs
@@ -420,9 +420,10 @@ impl <L, M> fmt::Debug for Server<L, M> where L: Log, M: StateMachine {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     extern crate env_logger;
+    extern crate test;
 
     use std::collections::HashMap;
     use std::io::{self, Read, Write};
@@ -431,6 +432,7 @@ mod test {
 
     use capnp::{serialize, MessageReader, ReaderOptions};
     use mio::EventLoop;
+    use test::Bencher;
 
     use ClientId;
     use Result;
@@ -757,5 +759,35 @@ mod test {
         event_loop.run_once(&mut server).unwrap();
 
         assert_eq!(peer_id, read_server_preamble(&mut in_stream));
+    }
+
+    /// Literally the same thing as above.
+    #[bench]
+    fn bench_connection_send(b: &mut Bencher) {
+        setup_test!("test_connection_send");
+        b.iter(|| {
+            let peer_id = ServerId::from(1);
+
+            let peer_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+
+            let mut peers = HashMap::new();
+            peers.insert(peer_id, peer_listener.local_addr().unwrap());
+            let (mut server, mut event_loop) = new_test_server(peers).unwrap();
+
+            // Accept the server's connection.
+            let (mut in_stream, _)  = peer_listener.accept().unwrap();
+
+            // Accept the preamble.
+            event_loop.run_once(&mut server).unwrap();
+            assert_eq!(ServerId::from(0), read_server_preamble(&mut in_stream));
+
+            // Send a test message (the type is not important).
+            let mut actions = Actions::new();
+            actions.peer_messages.push((peer_id, messages::server_connection_preamble(peer_id)));
+            server.execute_actions(&mut event_loop, actions);
+            event_loop.run_once(&mut server).unwrap();
+
+            assert_eq!(peer_id, read_server_preamble(&mut in_stream));
+        })
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -139,7 +139,7 @@ impl FollowerState {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::collections::HashSet;
 
     use {LogIndex, ServerId};


### PR DESCRIPTION
`test` mods were renamed to `tests` because otherwise the `extern crate test` made it confusing.