### PR TITLE
peers advertise their peer address

### DIFF
--- a/examples/register.rs
+++ b/examples/register.rs
@@ -242,9 +242,10 @@ impl RegisterStateMachine {
 /// used in Raft. Feel encouraged to base yours of one of ours in these examples.
 impl state_machine::StateMachine for RegisterStateMachine {
 
-    /// `apply()` is called on when a client's `.propose()` is commited and reaches the state
-    /// machine. At this point it is durable and is going to be applied on at least half the nodes
-    /// within the next couple round trips.
+    /// `apply()` is called on when a client's `.propose()` is committed and
+    /// reaches the state machine. At this point the proposal is durably stored
+    /// on a majority of peers. The proposal will be applied to follower's state
+    /// machines after the next communication with the master.
     fn apply(&mut self, proposal: &[u8]) -> Vec<u8> {
         // Store the old value (example specific)
         let old_value = self.value.clone();
@@ -275,7 +276,7 @@ impl state_machine::StateMachine for RegisterStateMachine {
         response
     }
 
-    /// `query()` is called on when a client's `.query()` is recieved. It does not go through the
+    /// `query()` is called on when a client's `.query()` is received. It does not go through the
     /// persistent log, it does not mutate the state of the state machine, and it is intended to be
     /// fast.
     fn query(&self, query: &[u8]) -> Vec<u8> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,8 +22,8 @@ pub struct Client {
     /// The `Uuid` of the client, should be unique in the cluster.
     pub id: ClientId,
     /// The current connection to the current leader.
-    /// If it is none it may mean that there is no estabished leader or that there has been
-    /// a disconnection.
+    /// If it is `None`, there may be no established leader, or a connection
+    /// issue.
     leader_connection: Option<BufStream<TcpStream>>,
     /// A lookup for the cluster's nodes.
     cluster: HashSet<SocketAddr>,

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -163,6 +163,12 @@ impl <L, M> Consensus<L, M> where L: Log, M: StateMachine {
         &self.peers
     }
 
+    /// Updates the address at which to contact the node with the
+    /// given `Id`.
+    pub fn update_peer(&mut self, id: ServerId, addr: SocketAddr) -> () {
+        &self.peers.insert(id, addr).expect("new peer insertion not supported");
+    }
+
     /// Applies a peer message to the consensus module. This function dispatches a generic request
     /// to its appropriate handler.
     pub fn apply_peer_message<R>(&mut self, from: ServerId, message: &R, actions: &mut Actions)

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -158,13 +158,13 @@ impl <L, M> Consensus<L, M> where L: Log, M: StateMachine {
         actions
     }
 
-    /// Returns the peers (Id's only) of the consensus modules.
+    /// Returns the peers (`Id`s only) of the consensus modules.
     pub fn peers(&self) -> &HashMap<ServerId, SocketAddr> {
         &self.peers
     }
 
     /// Applies a peer message to the consensus module. This function dispatches a generic request
-    /// to it's appropriate handler.
+    /// to its appropriate handler.
     pub fn apply_peer_message<R>(&mut self, from: ServerId, message: &R, actions: &mut Actions)
     where R: MessageReader {
         push_log_scope!("{:?}", self);

--- a/src/messages.capnp
+++ b/src/messages.capnp
@@ -9,7 +9,7 @@ struct ConnectionPreamble {
     # client.
 
     id :union {
-        server @0 :UInt64;
+        server @0 :Peer;
         # Indicates that the connecting process is a Raft peer, and that all
         # further messages in the connection (in both directions) will be of
         # type Message.
@@ -20,6 +20,14 @@ struct ConnectionPreamble {
         # all replys from the server to the client will be of type
         # ClientResponse.
     }
+}
+
+struct Peer {
+   id @0 :UInt64;
+
+   addr @1 :Text;
+   # The address to use for reconnecting or to redirect clients to
+   # when not leader.
 }
 
 struct Message {
@@ -107,7 +115,7 @@ struct RequestVoteResponse {
     # up-to-date with the voter's log.
 
     internalError @5 :Text;
-    # An internal error occured; a description is included.
+    # An internal error occurred; a description is included.
   }
 }
 
@@ -133,13 +141,13 @@ struct PingRequest {
 struct PingResponse {
 
   term @0 :UInt64;
-  # The servers current term.
+  # The server's current term.
 
   index @1 :UInt64;
-  # The servers current index.
+  # The server's current index.
 
   state :union {
-  # The servers current state.
+  # The server's current state.
     leader @2 :Void;
     follower @3 :Void;
     candidate @4 :Void;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -19,12 +19,14 @@ use messages_capnp::{
 
 // ConnectionPreamble
 
-pub fn server_connection_preamble(id: ServerId) -> Rc<MallocMessageBuilder> {
+pub fn server_connection_preamble(id: ServerId, addr: &SocketAddr) -> Rc<MallocMessageBuilder> {
     let mut message = MallocMessageBuilder::new_default();
     {
-        message.init_root::<connection_preamble::Builder>()
+        let mut server = message.init_root::<connection_preamble::Builder>()
                .init_id()
-               .set_server(id.into());
+               .init_server();
+        server.set_addr(&format!("{}", addr));
+        server.set_id(id.into());
     }
     Rc::new(message)
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -514,7 +514,7 @@ mod tests {
     }
 
     /// Tests that a Server connects to peer at startup, and reconnects when the
-    /// connection is droped.
+    /// connection is dropped.
     #[test]
     fn test_peer_connect() {
         setup_test!("test_peer_connect");
@@ -588,7 +588,7 @@ mod tests {
         assert!(stream_shutdown(&mut in_stream));
     }
 
-    /// Tests that the server will accept a client connection, then dispose of
+    /// Tests that the server will accept a client connection, then disposes of
     /// it when the client disconnects.
     #[test]
     fn test_client_accept() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,6 +4,7 @@
 //! time as described by the Raft Consensus Algorithm.
 
 use std::{fmt, io};
+use std::str::FromStr;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::thread::{self, JoinHandle};
@@ -117,7 +118,7 @@ impl<L, M> Server<L, M> where L: Log, M: StateMachine {
             scoped_assert!(server.peer_tokens.insert(peer_id, token).is_none());
 
             let mut connection = &mut server.connections[token];
-            connection.send_message(messages::server_connection_preamble(id));
+            connection.send_message(messages::server_connection_preamble(id, &addr));
             try!(connection.register(&mut event_loop, token));
         }
 
@@ -259,26 +260,43 @@ impl<L, M> Server<L, M> where L: Log, M: StateMachine {
                 ConnectionKind::Unknown => {
                     let preamble = try!(message.get_root::<connection_preamble::Reader>());
                     match try!(preamble.get_id().which()) {
-                        connection_preamble::id::Which::Server(id) => {
-                            let peer_id = ServerId(id);
-                            scoped_debug!("received new connection from {:?}", peer_id);
+                        connection_preamble::id::Which::Server(peer) => {
+                            let peer = try!(peer);
+                            let peer_id = ServerId(peer.get_id());
+
+                            // Not the source address of this connection, but the
+                            // address the peer tells us it's listening on.
+                            let peer_addr = SocketAddr::from_str(try!(peer.get_addr())).unwrap();
+                            scoped_debug!("received new connection from {:?} ({})", peer_id, peer_addr);
 
                             self.connections[token].set_kind(ConnectionKind::Peer(peer_id));
-                            let prev_token = self.peer_tokens
-                                                 .insert(peer_id, token)
-                                                 .expect("peer token not found");
+                            // Use the advertised address, not the remote's source
+                            // address, for future retries in this connection.
+                            self.connections[token].set_addr(peer_addr);
 
-                            // Close the existing connection.
-                            self.connections
-                                .remove(prev_token)
-                                .expect("peer connection not found");
+                            let prev_token = Some(self.peer_tokens
+                                                      .insert(peer_id, token)
+                                                      .expect("peer token not found"));
 
-                            // Clear any timeouts associated with the existing connection.
-                            self.reconnection_timeouts
-                                .remove(&prev_token)
-                                .map(|handle| scoped_assert!(event_loop.clear_timeout(handle)));
+                            // Close the existing connection, if any.
+                            // Currently, prev_token is never `None`; see above.
+                            // With config changes, this will have to be handled.
+                            match prev_token {
+                                Some(tok) => {
+                                    self.connections
+                                        .remove(tok)
+                                        .expect("peer connection not found");
 
-                            // TODO: add reconnect messages from consensus
+                                    // Clear any timeouts associated with the existing connection.
+                                    self.reconnection_timeouts
+                                        .remove(&tok)
+                                        .map(|handle| scoped_assert!(event_loop.clear_timeout(handle)));
+                                }
+                                _ => unreachable!()
+                            }
+                            // Inform consensus about the new peer address.
+                            self.consensus.update_peer(peer_id, peer_addr)
+                            // TODO: add reconnect messages from consensus.
                         },
                         connection_preamble::id::Which::Client(Ok(id)) => {
                             let client_id = try!(ClientId::from_bytes(id));
@@ -400,7 +418,8 @@ impl<L, M> Handler for Server<L, M> where L: Log, M: StateMachine {
                 scoped_assert!(self.reconnection_timeouts.remove(&token).is_some(),
                                "{:?} missing timeout: {:?}", self.connections[token], timeout);
                 self.connections[token]
-                    .reconnect_peer(self.id)
+                    // TODO(tschottdorf): alternatives to unwrap() here?
+                    .reconnect_peer(self.id, &self.listener.local_addr().unwrap())
                     .and_then(|_| self.connections[token].register(event_loop, token))
                     .unwrap_or_else(|error| {
                         scoped_warn!("unable to reconnect connection {:?}: {}",
@@ -467,8 +486,8 @@ mod tests {
         let preamble = message.get_root::<connection_preamble::Reader>().unwrap();
 
         match preamble.get_id().which().unwrap() {
-            connection_preamble::id::Which::Server(id) => {
-                ServerId::from(id)
+            connection_preamble::id::Which::Server(peer) => {
+                ServerId::from(peer.unwrap().get_id())
             },
             _ => {
                 panic!("unexpected preamble id");
@@ -578,14 +597,22 @@ mod tests {
         let mut out_stream = TcpStream::connect(server_addr).unwrap();
         event_loop.run_once(&mut server).unwrap();
 
+        // This is what the new peer tells the server is listening address is.
+        let fake_peer_addr = SocketAddr::from_str("192.168.0.1:12345").unwrap();
         // Send server the preamble message to the server.
-        serialize::write_message(&mut out_stream, &*messages::server_connection_preamble(peer_id))
+        serialize::write_message(&mut out_stream, &*messages::server_connection_preamble(peer_id, &fake_peer_addr))
                  .unwrap();
         out_stream.flush().unwrap();
         event_loop.run_once(&mut server).unwrap();
 
+        // Make sure that reconnecting updated the peer address
+        // known to `Consensus` with the one given in the preamble.
+        assert_eq!(server.consensus.peers()[&peer_id], fake_peer_addr);
         // Check that the server has closed the old connection.
         assert!(stream_shutdown(&mut in_stream));
+        // Check that there's a connection which has the fake address
+        // stored for reconnection purposes.
+        assert!(server.connections.iter().any(|conn| conn.addr().port() == 12345))
     }
 
     /// Tests that the server will accept a client connection, then disposes of
@@ -742,7 +769,8 @@ mod tests {
         let peer_listener = TcpListener::bind("127.0.0.1:0").unwrap();
 
         let mut peers = HashMap::new();
-        peers.insert(peer_id, peer_listener.local_addr().unwrap());
+        let peer_addr = peer_listener.local_addr().unwrap();
+        peers.insert(peer_id, peer_addr);
         let (mut server, mut event_loop) = new_test_server(peers).unwrap();
 
         // Accept the server's connection.
@@ -754,7 +782,7 @@ mod tests {
 
         // Send a test message (the type is not important).
         let mut actions = Actions::new();
-        actions.peer_messages.push((peer_id, messages::server_connection_preamble(peer_id)));
+        actions.peer_messages.push((peer_id, messages::server_connection_preamble(peer_id, &peer_addr)));
         server.execute_actions(&mut event_loop, actions);
         event_loop.run_once(&mut server).unwrap();
 
@@ -771,7 +799,8 @@ mod tests {
             let peer_listener = TcpListener::bind("127.0.0.1:0").unwrap();
 
             let mut peers = HashMap::new();
-            peers.insert(peer_id, peer_listener.local_addr().unwrap());
+            let peer_addr = peer_listener.local_addr().unwrap();
+            peers.insert(peer_id, peer_addr);
             let (mut server, mut event_loop) = new_test_server(peers).unwrap();
 
             // Accept the server's connection.
@@ -783,7 +812,7 @@ mod tests {
 
             // Send a test message (the type is not important).
             let mut actions = Actions::new();
-            actions.peer_messages.push((peer_id, messages::server_connection_preamble(peer_id)));
+            actions.peer_messages.push((peer_id, messages::server_connection_preamble(peer_id, &peer_addr)));
             server.execute_actions(&mut event_loop, actions);
             event_loop.run_once(&mut server).unwrap();
 


### PR DESCRIPTION
via the preamble. For inbound connections, the preamble
is the authoritative source of the peer's listening address.
The information updates the `Consensus` instance as well as
the `Connection`.

relates to #92, though I wouldn't quite say "fixes" yet.

I haven't had much of my Rust reviewed, so pointers appreciated.