### PR TITLE
Fix Catchup

### DIFF
--- a/src/messages.capnp
+++ b/src/messages.capnp
@@ -72,9 +72,10 @@ struct AppendEntriesResponse {
     # The `AppendEntries` request failed because the follower has a greater term
     # than the leader.
 
-    inconsistentPrevEntry @3 :Void;
+    inconsistentPrevEntry @3 :UInt64;
     # The `AppendEntries` request failed because the follower failed the
-    # previous entry term and index checks.
+    # previous entry term and index checks. Includes the index of the
+    # inconsistent entry.
 
     internalError @4 :Text;
     # an internal error occured; a description is included.

--- a/src/messages.capnp
+++ b/src/messages.capnp
@@ -30,7 +30,18 @@ struct Peer {
    # when not leader.
 }
 
+struct Entry {
+    # A log entry.
+
+    term @0 :UInt64;
+    # The term of the entry.
+
+    data @1 :Data;
+    # The user-defined data of the entry.
+}
+
 struct Message {
+
     union {
         appendEntriesRequest @0 :AppendEntriesRequest;
         appendEntriesResponse @1 :AppendEntriesResponse;
@@ -50,7 +61,7 @@ struct AppendEntriesRequest {
   prevLogTerm @2 :UInt64;
   # Term of prevLogIndex entry.
 
-  entries @3 :List(Data);
+  entries @3 :List(Entry);
   # Log entries to store (empty for heartbeat; may send more than one for
   # efficiency).
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -46,7 +46,7 @@ pub fn client_connection_preamble(id: ClientId) -> Rc<MallocMessageBuilder> {
 pub fn append_entries_request(term: Term,
                               prev_log_index: LogIndex,
                               prev_log_term: Term,
-                              entries: &[&[u8]],
+                              entries: &[(Term, &[u8])],
                               leader_commit: LogIndex)
                               -> Rc<MallocMessageBuilder> {
     let mut message = MallocMessageBuilder::new_default();
@@ -60,7 +60,9 @@ pub fn append_entries_request(term: Term,
 
         let mut entry_list = request.init_entries(entries.len() as u32);
         for (n, entry) in entries.iter().enumerate() {
-            entry_list.set(n as u32, entry);
+            let mut slot = entry_list.borrow().get(n as u32);
+            slot.set_term(entry.0.into());
+            slot.set_data(entry.1);
         }
     }
     Rc::new(message)

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -88,13 +88,13 @@ pub fn append_entries_response_stale_term(term: Term) -> Rc<MallocMessageBuilder
     Rc::new(message)
 }
 
-pub fn append_entries_response_inconsistent_prev_entry(term: Term) -> Rc<MallocMessageBuilder> {
+pub fn append_entries_response_inconsistent_prev_entry(term: Term, index: LogIndex) -> Rc<MallocMessageBuilder> {
     let mut message = MallocMessageBuilder::new_default();
     {
         let mut response = message.init_root::<message::Builder>()
                                   .init_append_entries_response();
         response.set_term(term.into());
-        response.set_inconsistent_prev_entry(());
+        response.set_inconsistent_prev_entry(index.into());
     }
     Rc::new(message)
 }


### PR DESCRIPTION
(Closes #97, much more info there)

Steps to reproduce:

* `cd experiments/tmux/hashmap-local-3`
* `./dashboard` to get 4 tabs.
* In *Server 1* `RUST_LOG=raft::consensus=debug ./server 1`
* In *Server 2* `RUST_LOG=raft::consensus=debug ./server 2`
* In *Server 3* `RUST_LOG=raft::consensus=debug ./server 3`
* In *Command Seat* `./put foo bar` a few times (doesn't matter really)
* Look for the leader in the servers, kill it.
* Restart the leader after a moment.
* Observe looping behaivor.

This fixes is by:
* Having `append_entries` carry the entry terms as well.
* Correctly reporting back the right index.

@danburkert please review. :)